### PR TITLE
Changed genfonts.sh shell to explicitly be bash

### DIFF
--- a/fonts/genfonts.sh
+++ b/fonts/genfonts.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ## Safe execution
 # -e: exit if subcommand fails


### PR DESCRIPTION
The option "-o pipefail" is supported by /bin/bash but not
/bin/dash, so the former dependency on /bin/sh by genfonts.sh
causes the script to fail if the user is running on a machine on
which /bin/sh is soft-linked to /bin/dash instead of /bin/bash.